### PR TITLE
Handle composing and paused stanzas as per XEP-0085

### DIFF
--- a/lib/junction/middleware/message.js
+++ b/lib/junction/middleware/message.js
@@ -19,6 +19,8 @@ var events = require('events')
  *   - `normal`     the message is a standalone message that is sent outside the context of a one-to-one conversation or multi-user chat environment, and to which it is expected that the recipient will reply
  *   - `headline`   the message provides an alert, a notification, or other transient information to which no reply is expected
  *   - `err`        an error has occurred regarding processing of a previously sent message stanza
+ *   - `composing`  the user is composing a message
+ *   - `paused`     the user was composing a message but has now stopped
  *
  * Examples:
  *


### PR DESCRIPTION
Junction was firing `chat` events for these state events. In my case the sample "hello" app was sending me two messages, one of which was "You said: undefined". I've modified the code to detect the composing and paused state events.
